### PR TITLE
Add missing index.html file

### DIFF
--- a/react-webpack/public/index.html
+++ b/react-webpack/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Webpack</title>
+</head>
+<body>
+<div id="root"></div>
+</body>
+</html>


### PR DESCRIPTION
The webpack build is expecting a `index.html` file in `public` folder. I believe this file was simply left out by mistake.